### PR TITLE
added endpoint host/port logic

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"time"
 
+	"net"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 )
@@ -89,6 +91,11 @@ func New(context *cli.Context) *Config {
 	loggingLevel, err = logrus.ParseLevel(logLevelArg)
 	if err != nil {
 		loggingLevel = logrus.DebugLevel
+	}
+
+	endpointHost := context.String(endpointHost)
+	if endpointHost == "" {
+		endpointHost = LocalIP()
 	}
 
 	return &Config{
@@ -237,4 +244,23 @@ func (c *Config) Validate(validateCreds bool) error {
 	}
 
 	return Validate(validators)
+}
+
+// LocalIP retrieves the IP address of the sidecar
+func LocalIP() string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return ""
+	}
+
+	for _, address := range addrs {
+		// check the address type and if it is not a loopback return it
+		if ipNet, ok := address.(*net.IPNet); ok && !ipNet.IP.IsLoopback() {
+			if ipNet.IP.To4() != nil {
+				return ipNet.IP.String()
+			}
+		}
+	}
+
+	return ""
 }

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/amalgam8/registry/client"
 	"github.com/amalgam8/sidecar/config"
@@ -113,12 +115,19 @@ func sidecarMain(conf config.Config) error {
 			return err
 		}
 
-		agent, err := register.NewRegistrationAgent(register.RegistrationConfig{
-			Client: registryClient,
-			ServiceInstance: &client.ServiceInstance{
-				ServiceName: conf.ServiceName,
-				TTL:         60,
+		address := fmt.Sprintf("%v:%v", conf.EndpointHost, conf.EndpointPort)
+		serviceInstance := &client.ServiceInstance{
+			ServiceName: conf.ServiceName,
+			Endpoint: client.ServiceEndpoint{
+				Type:  "http",
+				Value: address,
 			},
+			TTL: 60,
+		}
+
+		agent, err := register.NewRegistrationAgent(register.RegistrationConfig{
+			Client:          registryClient,
+			ServiceInstance: serviceInstance,
 		})
 		if err != nil {
 			logrus.WithError(err).Error("Could not create registry agent")


### PR DESCRIPTION
As noted by @zcahana, logic for passing in the endpoint host/port and defaulting to the local IP if the host was not provided was not present. This commit should resolve the issue.