### PR TITLE
Travis support for releasing binaries to GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ _testmain.go
 
 # Build
 bin/
+release/
 
 # Logs
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,43 @@
 language: go
 
+# Enable Travis container-based infrastructure
+sudo: false
+
+# Go versions to build with
 go:
     - 1.6
     - 1.5
 
 env:
     global:
+        # Required for Go 1.5 build
         - GO15VENDOREXPERIMENT=1
+    matrix:
+        # Platforms to build for
+        - PLATFORM=linux/amd64
 
 script:
-    - make verify
+    # Need to set explicitly, as these are unset by 'gimme'
+    - export GOOS=${PLATFORM%/*}
+    - export GOARCH=${PLATFORM#*/}
+    
+    # Analyze, test and build the code, and then package the binary
+    - make verify release
 
-sudo: false
+deploy:
+    
+    # Upload files to GitHub as release attachments
+    provider: releases
+    api_key: $GITHUB_TOKEN
+      
+    # Keep artifacts produced during the build
+    skip_cleanup: true
+    
+    # Upload anything under the release directory
+    file_glob: true
+    file: release/*
+
+    # Trigger only when building a tagged commit, on Go 1.6
+    on:
+        tags: true
+        go: 1.6

--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,26 @@
 SHELL 		:= /bin/bash
 APP_NAME	:= sidecar
 APP_VER		:= 0.1
-IMAGE_NAME  := $(APP_NAME):$(APP_VER)
 DOCKERFILE  := ./docker/Dockerfile.ubuntu
 BINDIR		:= bin
+RELEASEDIR  := release
 
 GO			:= GO15VENDOREXPERIMENT=1 go
 
+ifndef GOOS
+    GOOS := $(shell $(GO) env GOHOSTOS)
+endif
+
+ifndef GOARCH
+	GOARCH := $(shell $(GO) env GOHOSTARCH)
+endif
+ 
 GOFILES		= $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 GODIRS		= $(shell $(GO) list -f '{{.Dir}}' ./... | grep -vxFf <($(GO) list -f '{{.Dir}}' ./vendor/...))
 GOPKGS		= $(shell $(GO) list ./... | grep -vxFf <($(GO) list ./vendor/...))
+
+IMAGE_NAME   := $(APP_NAME):$(APP_VER)
+RELEASE_NAME := $(APP_NAME)-$(APP_VER)-$(GOOS)-$(GOARCH)
 
 # build flags to create a statically linked binary (required for scratch-based image)
 BUILDFLAGS	:= -a -installsuffix nocgo -tags netgo
@@ -73,6 +84,7 @@ clean:
 	@echo "--> cleaning compiled objects and binaries"
 	@$(GO) clean -tags netgo -i $(GOPKGS)
 	@rm -rf $(BINDIR)/*
+	@rm -rf $(RELEASEDIR)/*
 
 #--------
 #-- test
@@ -126,11 +138,16 @@ depend.install:	tools.glide
 #----------
 #-- docker
 #----------
-.PHONY: docker
+.PHONY: docker release
 
 docker:
 	@echo "--> building docker image"
 	@docker build -t $(IMAGE_NAME) -f $(DOCKERFILE) .
+	
+release:
+	@echo "--> packaging release"
+	@mkdir -p $(RELEASEDIR) 
+	@tar -czf $(RELEASEDIR)/$(RELEASE_NAME).tar.gz --transform 's:^.*/::' $(BINDIR)/$(APP_NAME) README.md LICENSE
 
 #---------------
 #-- tools

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 #------------------------------------------------------------------------------
 
 SHELL 		:= /bin/bash
-APP_NAME	:= sidecar
+APP_NAME	:= a8sidecar
 APP_VER		:= 0.1
 DOCKERFILE  := ./docker/Dockerfile.ubuntu
 BINDIR		:= bin

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -126,7 +126,7 @@ RUN set -ex \
 ADD docker/splib.lua /lua/splib.lua
 ADD docker/filebeat.yml /etc/filebeat/filebeat.yml
 
-ADD /bin/sidecar /usr/bin/a8sidecar
+ADD /bin/a8sidecar /usr/bin/a8sidecar
 
 ENTRYPOINT ["/usr/bin/a8sidecar", "--supervise=false"]
 

--- a/docker/Dockerfile.sidecar.regonly
+++ b/docker/Dockerfile.sidecar.regonly
@@ -23,7 +23,7 @@
 #
 FROM ubuntu:14.04
 
-ADD /bin/sidecar /usr/bin/a8sidecar
+ADD /bin/a8sidecar /usr/bin/a8sidecar
 #COPY /locale /locale
 
 ENTRYPOINT ["/usr/bin/a8sidecar", "--proxy=false", "--log=false", "--supervise=false"]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -66,7 +66,7 @@ RUN \
 ADD docker/splib.lua /lua/splib.lua
 ADD docker/filebeat.yml /etc/filebeat/filebeat.yml
 
-ADD /bin/sidecar /usr/bin/a8sidecar
+ADD /bin/a8sidecar /usr/bin/a8sidecar
 #COPY /locale /locale
 
 ENTRYPOINT ["/usr/bin/a8sidecar", "--supervise=false"]


### PR DESCRIPTION
This PR enhances the Travis build to uploaded packaged binaries (e.g., a8sidecar-v0.1.0-linux-amd64.tar.gz) as release attachments in GitHub, whenever a tagged commit is built.

(Follow-up PR to amalgam8/registry#12)