### PR TITLE
fixed registration logic to register with service version

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,7 +64,7 @@ type Controller struct {
 // Config TODO
 type Config struct {
 	ServiceName    string
-	ServiceVerion  string
+	ServiceVersion string
 	EndpointHost   string
 	EndpointPort   int
 	LogstashServer string
@@ -100,7 +100,7 @@ func New(context *cli.Context) *Config {
 
 	return &Config{
 		ServiceName:    context.String(serviceName),
-		ServiceVerion:  context.String(serviceVersion),
+		ServiceVersion: context.String(serviceVersion),
 		EndpointHost:   context.String(endpointHost),
 		EndpointPort:   context.Int(endpointPort),
 		LogstashServer: context.String(logstashServer),

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ import (
 
 	"fmt"
 
+	"encoding/json"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/amalgam8/registry/client"
 	"github.com/amalgam8/sidecar/config"
@@ -123,6 +125,15 @@ func sidecarMain(conf config.Config) error {
 				Value: address,
 			},
 			TTL: 60,
+		}
+
+		if conf.ServiceVersion != "" {
+			data, err := json.Marshal(map[string]string{"version": conf.ServiceVersion})
+			if err == nil {
+				serviceInstance.Metadata = data
+			} else {
+				logrus.WithError(err).Warn("Could not marshal service version metadata")
+			}
 		}
 
 		agent, err := register.NewRegistrationAgent(register.RegistrationConfig{


### PR DESCRIPTION
The logic for registering with registry using the service version was broken. This PR resolves that issue.